### PR TITLE
Replace deprecated autoconf macros

### DIFF
--- a/m4/ax_create_stdint_h.m4
+++ b/m4/ax_create_stdint_h.m4
@@ -173,13 +173,17 @@ AC_CACHE_VAL([ac_cv_header_stdint_t],[
 old_CXXFLAGS="$CXXFLAGS" ; CXXFLAGS=""
 old_CPPFLAGS="$CPPFLAGS" ; CPPFLAGS=""
 old_CFLAGS="$CFLAGS"     ; CFLAGS=""
-AC_TRY_COMPILE([#include <stdint.h>],[int_least32_t v = 0;],
+AC_COMPILE_IFELSE([
+AC_LANG_SOURCE([[#include <stdint.h>
+int main(void){int_least32_t v = 0; return 0;}]])],
 [ac_cv_stdint_result="(assuming C99 compatible system)"
  ac_cv_header_stdint_t="stdint.h"; ],
 [ac_cv_header_stdint_t=""])
 if test "$GCC" = "yes" && test ".$ac_cv_header_stdint_t" = "."; then
 CFLAGS="-std=c99"
-AC_TRY_COMPILE([#include <stdint.h>],[int_least32_t v = 0;],
+AC_COMPILE_IFELSE([
+AC_LANG_SOURCE([[#include <stdint.h>
+int main(void){int_least32_t v = 0; return 0;}]])],
 [AC_MSG_WARN(your GCC compiler has a defunct stdint.h for its default-mode)])
 fi
 CXXFLAGS="$old_CXXFLAGS"

--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -103,7 +103,9 @@ if test x"$PTHREAD_LIBS$PTHREAD_CFLAGS" != x; then
         save_LIBS="$LIBS"
         LIBS="$PTHREAD_LIBS $LIBS"
         AC_MSG_CHECKING([for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS])
-        AC_TRY_LINK_FUNC([pthread_join], [ax_pthread_ok=yes])
+        AC_LINK_IFELSE([
+          AC_LANG_CALL([], pthread_join)
+        ], [ax_pthread_ok=yes], [])
         AC_MSG_RESULT([$ax_pthread_ok])
         if test x"$ax_pthread_ok" = xno; then
                 PTHREAD_LIBS=""

--- a/m4/ax_string_strcasecmp.m4
+++ b/m4/ax_string_strcasecmp.m4
@@ -37,11 +37,15 @@ AU_ALIAS([ETR_STRING_STRCASECMP], [AX_STRING_STRCASECMP])
 AC_DEFUN([AX_STRING_STRCASECMP],
 [
 AC_CACHE_CHECK([for strcasecmp() in string.h], ac_cv_string_strcasecmp, [
-        AC_TRY_LINK(
-                [ #include <string.h> ],
-                [ strcasecmp("foo", "bar"); ],
-                ac_cv_string_strcasecmp=yes,
-                ac_cv_string_strcasecmp=no)
+        AC_LINK_IFELSE([
+                AC_LANG_SOURCE([[
+#include <string.h>
+int main(void){
+  strcasecmp("foo", "bar");
+  return 0;
+} ]])],
+                [ac_cv_string_strcasecmp=yes],
+                [ac_cv_string_strcasecmp=no])
 ])
 
         if test x"$ac_cv_string_strcasecmp" = "xyes"

--- a/m4/gtk-2.0.m4
+++ b/m4/gtk-2.0.m4
@@ -76,7 +76,8 @@ dnl Now check if the installed GTK+ is sufficiently new. (Also sanity
 dnl checks the results of pkg-config to some extent)
 dnl
       rm -f conf.gtktest
-      AC_TRY_RUN([
+      AC_RUN_IFELSE([
+        AC_LANG_SOURCE([[
 #include <gtk/gtk.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -147,9 +148,9 @@ main ()
     }
   return 1;
 }
-],, no_gtk=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
-       CFLAGS="$ac_save_CFLAGS"
-       LIBS="$ac_save_LIBS"
+        ]])], [], [no_gtk=yes], [echo $ac_n "cross compiling; assumed OK... $ac_c"])
+      CFLAGS="$ac_save_CFLAGS"
+      LIBS="$ac_save_LIBS"
      fi
   fi
   if test "x$no_gtk" = x ; then
@@ -169,21 +170,25 @@ main ()
 	  ac_save_LIBS="$LIBS"
           CFLAGS="$CFLAGS $GTK_CFLAGS"
           LIBS="$LIBS $GTK_LIBS"
-          AC_TRY_LINK([
+          AC_LINK_IFELSE([
+            AC_LANG_SOURCE([[
 #include <gtk/gtk.h>
 #include <stdio.h>
-],      [ return ((gtk_major_version) || (gtk_minor_version) || (gtk_micro_version)); ],
-        [ echo "*** The test program compiled, but did not run. This usually means"
-          echo "*** that the run-time linker is not finding GTK+ or finding the wrong"
-          echo "*** version of GTK+. If it is not finding GTK+, you'll need to set your"
-          echo "*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point"
-          echo "*** to the installed location  Also, make sure you have run ldconfig if that"
-          echo "*** is required on your system"
-	  echo "***"
-          echo "*** If you have an old version installed, it is best to remove it, although"
-          echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
-        [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means GTK+ is incorrectly installed."])
+int main(void){
+  return ((gtk_major_version) || (gtk_minor_version) || (gtk_micro_version));
+}
+            ]])],
+            [ echo "*** The test program compiled, but did not run. This usually means"
+              echo "*** that the run-time linker is not finding GTK+ or finding the wrong"
+              echo "*** version of GTK+. If it is not finding GTK+, you'll need to set your"
+              echo "*** LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf to point"
+              echo "*** to the installed location  Also, make sure you have run ldconfig if that"
+              echo "*** is required on your system"
+              echo "***"
+              echo "*** If you have an old version installed, it is best to remove it, although"
+              echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
+            [ echo "*** The test program failed to compile or link. See the file config.log for the"
+              echo "*** exact error that occured. This usually means GTK+ is incorrectly installed." ])
           CFLAGS="$ac_save_CFLAGS"
           LIBS="$ac_save_LIBS"
        fi

--- a/m4/sdl.m4
+++ b/m4/sdl.m4
@@ -62,7 +62,8 @@ dnl Now check if the installed SDL is sufficiently new. (Also sanity
 dnl checks the results of sdl-config to some extent
 dnl
       rm -f conf.sdltest
-      AC_TRY_RUN([
+      AC_RUN_IFELSE([
+        AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -72,7 +73,7 @@ char*
 my_strdup (char *str)
 {
   char *new_str;
-  
+
   if (str)
     {
       new_str = (char *)malloc ((strlen (str) + 1) * sizeof(char));
@@ -80,7 +81,7 @@ my_strdup (char *str)
     }
   else
     new_str = NULL;
-  
+
   return new_str;
 }
 
@@ -119,7 +120,7 @@ int main (int argc, char *argv[])
     }
 }
 
-],, no_sdl=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+        ]])], [], [no_sdl=yes], [echo $ac_n "cross compiling; assumed OK... $ac_c"])
        CFLAGS="$ac_save_CFLAGS"
        LIBS="$ac_save_LIBS"
      fi
@@ -141,15 +142,16 @@ int main (int argc, char *argv[])
           echo "*** Could not run SDL test program, checking why..."
           CFLAGS="$CFLAGS $SDL_CFLAGS"
           LIBS="$LIBS $SDL_LIBS"
-          AC_TRY_LINK([
+          AC_LINK_IFELSE([
+            AC_LANG_SOURCE([[
 #include <stdio.h>
 #include "SDL.h"
-
-int main(int argc, char *argv[])
-{ return 0; }
 #undef  main
 #define main K_and_R_C_main
-],      [ return 0; ],
+int main(int argc, char *argv[])
+{ return 0; }
+            ]])],
+            [ return 0; ],
         [ echo "*** The test program compiled, but did not run. This usually means"
           echo "*** that the run-time linker is not finding SDL or finding the wrong"
           echo "*** version of SDL. If it is not finding SDL, you'll need to set your"


### PR DESCRIPTION
## Summary
- modernize autoconf macros to silence deprecation warnings
- regenerate configure (fails in CI env because automake is missing)

## Testing
- `./autogen.sh` *(fails: aclocal missing)*
- `autoconf` *(fails due to missing automake macros)*

------
https://chatgpt.com/codex/tasks/task_e_688c6d6864c4832e8b98c52a971061d8