### PR TITLE
Xdisplay fix

### DIFF
--- a/debugger/gdbserver.c
+++ b/debugger/gdbserver.c
@@ -525,7 +525,7 @@ static void* network_thread(void* arg)
             }
         }
 
-        int socklen;
+        socklen_t socklen;
         struct sockaddr_in connected_addr;
         int sock = accept(gdbserver_socket, (struct sockaddr*)&connected_addr, &socklen);
         if (sock < 0)

--- a/ui/xlib/xdisplay.c
+++ b/ui/xlib/xdisplay.c
@@ -975,7 +975,10 @@ xdisplay_destroy_image(void)
     shm_used = 0;
   }
 #endif
-  if( image ) XDestroyImage( image ); image = NULL;
+  if( image ) {
+    XDestroyImage( image );
+    image = NULL;
+  }
 }
 
 static void


### PR DESCRIPTION
Misleadingly indented as if it were guarded by the `if` statement

